### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This crate is build once a week with latest [rust stable] version and with lates
 ## Usage
 Just pull the docker image from the Docker hub:
 
-`docker run --rm -p 8888:8888 sylwekrapala/jupiter-rust`
+`docker run --rm -p 8888:8888 sylwekrapala/jupyter-rust`
 
 And go to `http://localhost:8888` (in the console log you will get a token to log).
 
 ### Don't lose your work
-`docker run -v $(pwd)/notebooks:/notebooks -p 8888:8888 sylwekrapala/jupiter-rust`
+`docker run -v $(pwd)/notebooks:/notebooks -p 8888:8888 sylwekrapala/jupyter-rust`
 
 The disadvantage of this is that files in `notebooks` would be owned by root.


### PR DESCRIPTION
The word "jupyter" was misspelled in the commands.